### PR TITLE
Adds note regarding undocumented retainPlayer tag behaviour

### DIFF
--- a/contents/docs/sdk/features/queueing/index.mdx
+++ b/contents/docs/sdk/features/queueing/index.mdx
@@ -100,7 +100,9 @@ public void returnToLobby(Player player) {
 
 Keeps a player in their current queue, avoiding entry into specific game tags. This is useful when a player wants to continue playing your mode rather than playing the tag rotation.
 
-**Note**: This will clear the player's joined tag (if any exists) and cause `joinedThroughTag` to return `false`.
+<Note type="warning">
+This will clear the player's joined tag (if any exists) and cause `joinedThroughTag` to return `false`.
+</Note>
 
 - **Parameters**:
     - `player`: The player to retain.

--- a/contents/docs/sdk/features/queueing/index.mdx
+++ b/contents/docs/sdk/features/queueing/index.mdx
@@ -100,6 +100,8 @@ public void returnToLobby(Player player) {
 
 Keeps a player in their current queue, avoiding entry into specific game tags. This is useful when a player wants to continue playing your mode rather than playing the tag rotation.
 
+**Note**: This will clear the player's joined tag (if any exists) and cause `joinedThroughTag` to return `false`.
+
 - **Parameters**:
     - `player`: The player to retain.
 - **Returns**: A `CompletableFuture<Void>` that completes once the player is retained


### PR DESCRIPTION
Currently within the SDK, when calling `retainPlayer`, `joinedThroughTag` will return `false` regardless of the initial method of joining the game. This is not documented within the docs/source code.

This PR just adds a quick note to specify said behaviour.