### PR TITLE
Fix ToC not being usable

### DIFF
--- a/components/navigation/clipboardcopy.tsx
+++ b/components/navigation/clipboardcopy.tsx
@@ -13,14 +13,14 @@ const ClipboardCopy = () => {
         if (target && target.closest) {
           const headingElement = target.closest('h2, h3, h4') as HTMLElement; // Type assertion for closest element
           if (headingElement) {
-            const headingText = headingElement.innerText; // innerText is valid on HTMLElement
-            const slug = headingText.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]+/g, '');
-            const url = `${window.location.href}#${slug}`;
-            navigator.clipboard.writeText(url);
+            const headingLink = headingElement.querySelector('a');
+            if (headingLink) {
+              navigator.clipboard.writeText(headingLink.href);
 
-            // Show copied message and hide after 2 seconds
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+              // Show copied message and hide after 2 seconds
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
+            }
           }
         }
       });

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -55,12 +55,12 @@ async function parseMdx<Frontmatter>(rawMdx: string) {
       parseFrontmatter: true,
       mdxOptions: {
         rehypePlugins: [
-          rehypeAddLinkIcon, // Add link icon to headings
           rehypeCodeTitles,
           rehypeKatex,
           rehypePrism,
           rehypeSlug,
           rehypeAutolinkHeadings,
+          rehypeAddLinkIcon, // Add link icon to headings
           postCopy,
         ],
         remarkPlugins: [remarkGfm],


### PR DESCRIPTION
Currently, the ToC on any page do not actually bring you to the section clicked. It attempts to look for the correct id, but the heading element itself does not have the correct id. 

**Example**
Say there's a page with a heading called "Test". It's heading element is assigned the id "test-" whereas the ToC clickable element looks for a element matching the query "#test". (Notice the hyphen difference) It cannot resolve this and will fail to scroll down to the heading.

The cause of this problem was the order of the `rehypePlugins` as putting `rehypeAddLinkIcon` at the top messed up the logic of `rehypeSlug`, which is responsible for creating the id of headings, and it was appending the extra hyphen.

This issue was also present when clicking the copy link icon next to any heading.

**Changes**
- Reordered `rehypePlugins` to resolve ids before appending link icon element
- Updated clipboard copy logic to resolve the `a` href value rather than recompute the slug.