### PR TITLE
Change it so that sublinks only open for depth 1

### DIFF
--- a/components/navigation/sublink.tsx
+++ b/components/navigation/sublink.tsx
@@ -22,7 +22,7 @@ function isRoute(item: Paths): item is Extract<Paths, { title: string; href: str
 
 export default function SubLink(props: Paths & { level: number; isSheet: boolean }) {
   const path = usePathname();
-  const [isOpen, setIsOpen] = useState(props.level == 0);
+  const [isOpen, setIsOpen] = useState(props.level === 0);
 
   useEffect(() => {
     // Expand the SubLink if it is a parent of the current SubLink page the browser is on.

--- a/components/navigation/sublink.tsx
+++ b/components/navigation/sublink.tsx
@@ -22,9 +22,10 @@ function isRoute(item: Paths): item is Extract<Paths, { title: string; href: str
 
 export default function SubLink(props: Paths & { level: number; isSheet: boolean }) {
   const path = usePathname();
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(props.level == 0);
 
   useEffect(() => {
+    // Expand the SubLink if it is a parent of the current SubLink page the browser is on.
     if (isRoute(props) && props.href && path !== props.href && path.includes(props.href)) {
       setIsOpen(true);
     }


### PR DESCRIPTION
**The Issue**
Currently, the sublinks on the lefthand navigation show all categories by default, this can "get a bit chaotic over time."

**Changes**
- Only show the immediate descendants of the root sublinks by default
- Adds comment to help explain the `useEffect` used for the expansion of parent sublinks of the current sublink page we are on.