### PR TITLE
docs: add a warning about the level session being constructed at stupid times

### DIFF
--- a/contents/docs/sdk/features/levels/index.mdx
+++ b/contents/docs/sdk/features/levels/index.mdx
@@ -25,6 +25,12 @@ rewardGame(@NonNull MineplexExperienceSession levelSession)
 ### In-built Example
 We have an in-built `MineplexExperienceSessionImpl` which implements the `MineplexExperienceSession` to provide session functionality. 
 
+<Note type="warning">
+You need to construct this premade implementation of the session at the START of each game (when your game starts & becomes playable), as we take into account the time you start the session for determining the amount of experience to give to players. 
+
+Do not start the session at the end of your game, or before players join, as this will give an innacurate amount of experience. 
+</Note>
+
 <Step>
     <StepItem title="Construct the session">
     ```java


### PR DESCRIPTION
People keep doing this, and asking me for help, so just making it very obvious.

# Thanks for contributing to our Studio Documentation!

To ensure quality and consistency, please complete the checklist below. Provide links and details where requested. This helps us verify everything is in order.

Please ignore any options that aren't applicable to your change.

## Documentation 

- [x] I have checked grammar and flow to be sure it's simple to understand
- [x] I have verified that all terms are consistent.
- [ ] I have confirmed all links are accurate and up to date.
- [ ] I have ensured each section includes all necessary details and meets the outlined objectives.
- [ ] I have checked that any images, diagrams, or tables are clear, correctly formatted, and enhance understanding.
 
## Testing

- [x] Required - I have ran this locally and it works.
- [x] I have verified functionality across all supported devices and browsers.
- [x] I have verified that existing features remain unaffected by recent changes.

Once completed, share all Pull Request (PR) links in the #documentation-chat channel for review by other partners and the Mineplex development team. Thank you for your effort in improving our documentation!